### PR TITLE
Prevent pixelation of small images by displaying it in orignal size by default

### DIFF
--- a/dist/iv-viewer.es.js
+++ b/dist/iv-viewer.es.js
@@ -275,7 +275,7 @@ function wrap(element, _ref) {
   var wrapper = document.createElement(tag);
   if (className) wrapper.className = className;
   if (id) wrapper.id = id;
-  if (style) wrapper.style = style;
+  if (style) wrapper.style.cssText = style;
   element.parentNode.insertBefore(wrapper, element);
   element.parentNode.removeChild(element);
   wrapper.appendChild(element);
@@ -643,10 +643,7 @@ function () {
 
         container = wrap(domElement, {
           className: 'iv-container iv-image-mode',
-          style: {
-            display: 'inline-block',
-            overflow: 'hidden'
-          }
+          style: 'display: inline-block; overflow: hidden',
         }); // hide the image and add iv-original-img class
 
         css(domElement, {

--- a/dist/iv-viewer.js
+++ b/dist/iv-viewer.js
@@ -281,7 +281,7 @@
     var wrapper = document.createElement(tag);
     if (className) wrapper.className = className;
     if (id) wrapper.id = id;
-    if (style) wrapper.style = style;
+    if (style) wrapper.style.cssText = style;
     element.parentNode.insertBefore(wrapper, element);
     element.parentNode.removeChild(element);
     wrapper.appendChild(element);
@@ -649,10 +649,7 @@
 
           container = wrap(domElement, {
             className: 'iv-container iv-image-mode',
-            style: {
-              display: 'inline-block',
-              overflow: 'hidden'
-            }
+            style: 'display: inline-block; overflow: hidden',
           }); // hide the image and add iv-original-img class
 
           css(domElement, {

--- a/lib/ImageViewer.js
+++ b/lib/ImageViewer.js
@@ -247,10 +247,7 @@ function () {
 
         container = (0, _util.wrap)(domElement, {
           className: 'iv-container iv-image-mode',
-          style: {
-            display: 'inline-block',
-            overflow: 'hidden'
-          }
+          style: 'display: inline-block; overflow: hidden',
         }); // hide the image and add iv-original-img class
 
         (0, _util.css)(domElement, {
@@ -794,8 +791,8 @@ function () {
           snapImage = _this$_elements6.snapImage,
           zoomHandle = _this$_elements6.zoomHandle; // calculate content width of image and snap image
 
-      var imageWidth = parseInt((0, _util.css)(image, 'width'), 10);
-      var imageHeight = parseInt((0, _util.css)(image, 'height'), 10);
+      var imageWidth = this._options.imageWidth ? this._options.imageWidth : parseInt((0, _util.css)(image, 'width'), 10);
+      var imageHeight = this._options.imageHeight ? this._options.imageHeight : parseInt((0, _util.css)(image, 'height'), 10);
       var contWidth = parseInt((0, _util.css)(container, 'width'), 10);
       var contHeight = parseInt((0, _util.css)(container, 'height'), 10);
       var snapViewWidth = snapView.clientWidth;
@@ -809,7 +806,11 @@ function () {
       var imgWidth;
       var imgHeight;
       var ratio = imageWidth / imageHeight;
-      imgWidth = imageWidth > imageHeight && contHeight >= contWidth || ratio * contHeight > contWidth ? contWidth : ratio * contHeight;
+      if (imageWidth > contWidth) {
+        imgWidth = imageWidth > imageHeight && contHeight >= contWidth || ratio * contHeight > contWidth ? contWidth : ratio * contHeight;
+      } else {
+        imgWidth = imageWidth;
+      }
       imgHeight = imgWidth / ratio;
       this._state.imageDim = {
         w: imgWidth,

--- a/lib/ImageViewer.js
+++ b/lib/ImageViewer.js
@@ -156,9 +156,19 @@ function () {
       var _this$_state = _this._state,
           snapViewVisible = _this$_state.snapViewVisible,
           zoomValue = _this$_state.zoomValue,
-          loaded = _this$_state.loaded;
+          loaded = _this$_state.loaded,
+          imageDim = _this$_state.imageDim,
+          containerDim = _this$_state.containerDim;
       var snapView = _this._elements.snapView;
       if (!_this._options.snapView) return;
+      var currImgWidth = imageDim.w * zoomValue / 100;
+      var currImgHeight = imageDim.h * zoomValue / 100;
+
+      if (currImgWidth <= containerDim.w && currImgHeight <= containerDim.h) {
+        _this._state.snapViewVisible = false;
+        return;
+      }
+
       if (snapViewVisible || zoomValue <= 100 || !loaded) return;
       clearTimeout(_this._frames.snapViewTimeout);
       _this._state.snapViewVisible = true;
@@ -247,7 +257,7 @@ function () {
 
         container = (0, _util.wrap)(domElement, {
           className: 'iv-container iv-image-mode',
-          style: 'display: inline-block; overflow: hidden',
+          style: 'display: inline-block; overflow: hidden'
         }); // hide the image and add iv-original-img class
 
         (0, _util.css)(domElement, {
@@ -569,11 +579,15 @@ function () {
           _this6.zoom(zoomValue, center);
         };
 
-        var endListener = function endListener() {
+        var endListener = function endListener(eEnd) {
           // unbind events
           events.pinchMove();
           events.pinchEnd();
-          _this6._state.zooming = false;
+          _this6._state.zooming = false; // properly resume move event if one finger remains
+
+          if (eEnd.touches.length === 1) {
+            _this6._sliders.imageSlider.startHandler(eEnd);
+          }
         }; // remove events if already assigned
 
 
@@ -806,11 +820,13 @@ function () {
       var imgWidth;
       var imgHeight;
       var ratio = imageWidth / imageHeight;
+
       if (imageWidth > contWidth) {
         imgWidth = imageWidth > imageHeight && contHeight >= contWidth || ratio * contHeight > contWidth ? contWidth : ratio * contHeight;
       } else {
         imgWidth = imageWidth;
       }
+
       imgHeight = imgWidth / ratio;
       this._state.imageDim = {
         w: imgWidth,

--- a/lib/util.js
+++ b/lib/util.js
@@ -144,7 +144,7 @@ function wrap(element, _ref) {
   var wrapper = document.createElement(tag);
   if (className) wrapper.className = className;
   if (id) wrapper.id = id;
-  if (style) wrapper.style = style;
+  if (style) wrapper.style.cssText = style;
   element.parentNode.insertBefore(wrapper, element);
   element.parentNode.removeChild(element);
   wrapper.appendChild(element);

--- a/src/ImageViewer.js
+++ b/src/ImageViewer.js
@@ -100,7 +100,10 @@ class ImageViewer {
       hiResImageSrc = domElement.getAttribute('high-res-src') || domElement.getAttribute('data-high-res-src');
 
       // wrap the image with iv-container div
-      container = wrap(domElement, { className: 'iv-container iv-image-mode', style: { display: 'inline-block', overflow: 'hidden' } });
+      container = wrap(domElement, {
+        className: 'iv-container iv-image-mode',
+        style: 'display: inline-block; overflow: hidden',
+      });
 
       // hide the image and add iv-original-img class
       css(domElement, {
@@ -643,8 +646,8 @@ class ImageViewer {
     const { image, container, snapView, snapImage, zoomHandle } = this._elements;
 
     // calculate content width of image and snap image
-    const imageWidth = parseInt(css(image, 'width'), 10);
-    const imageHeight = parseInt(css(image, 'height'), 10);
+    const imageWidth = this._options.imageWidth ? this._options.imageWidth : parseInt(css(image, 'width'), 10);
+    const imageHeight = this._options.imageHeight ? this._options.imageHeight : parseInt(css(image, 'height'), 10);
 
     const contWidth = parseInt(css(container, 'width'), 10);
     const contHeight = parseInt(css(container, 'height'), 10);
@@ -664,9 +667,13 @@ class ImageViewer {
 
     const ratio = imageWidth / imageHeight;
 
-    imgWidth = (imageWidth > imageHeight && contHeight >= contWidth) || ratio * contHeight > contWidth
-      ? contWidth
-      : ratio * contHeight;
+    if (imageWidth > contWidth) {
+      imgWidth = (imageWidth > imageHeight && contHeight >= contWidth) || ratio * contHeight > contWidth
+        ? contWidth
+        : ratio * contHeight;
+    } else {
+      imgWidth = imageWidth;
+    }
 
     imgHeight = imgWidth / ratio;
 

--- a/src/ImageViewer.js
+++ b/src/ImageViewer.js
@@ -829,10 +829,19 @@ class ImageViewer {
     };
   }
   showSnapView = (noTimeout) => {
-    const { snapViewVisible, zoomValue, loaded } = this._state;
+    const { snapViewVisible, zoomValue, loaded, imageDim, containerDim } = this._state;
     const { snapView } = this._elements;
 
     if (!this._options.snapView) return;
+
+    // Hide snapView if image is smaller than container, 
+    // in that case moving in the image is not necessary
+    const currImgWidth = imageDim.w * zoomValue / 100;
+    const currImgHeight = imageDim.h * zoomValue / 100;
+    if (currImgWidth <= containerDim.w && currImgHeight <= containerDim.h) {
+      this._state.snapViewVisible = false;
+      return;
+    }
 
     if (snapViewVisible || zoomValue <= 100 || !loaded) return;
 

--- a/src/util.js
+++ b/src/util.js
@@ -107,7 +107,7 @@ export function wrap (element, { tag = 'div', className, id, style }) {
   const wrapper = document.createElement(tag);
   if (className) wrapper.className = className;
   if (id) wrapper.id = id;
-  if (style) wrapper.style = style;
+  if (style) wrapper.style.cssText = style;
   element.parentNode.insertBefore(wrapper, element);
   element.parentNode.removeChild(element);
   wrapper.appendChild(element);


### PR DESCRIPTION
Adding small images features.
If image is smaller than container: 
-display it in its original size
-hide snap view until it's enough zoomed to be bigger than container

This work has been done to fix (partially) existing issue: https://github.com/s-yadav/iv-viewer/issues/22

Big thank you to Nuno Freire (@nfcf on github) for his two commits used in that fork: 
-https://github.com/nfcf/iv-viewer/commit/cf76a78fab8f68025fb02cb1d236f2c60a499a45
-https://github.com/nfcf/iv-viewer/commit/8564e9bd4c798dc9db52e6fe298f1a2e59e48e11