### PR TITLE
Fix "Could not find a declaration file" error

### DIFF
--- a/packages/iv-viewer/package.json
+++ b/packages/iv-viewer/package.json
@@ -3,6 +3,7 @@
   "version": "2.2.1",
   "description": "A zooming and panning plugin inspired by google photos for your web images.",
   "main": "lib/index.js",
+  "types": "iv-viewer.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/s-yadav/iv-viewer.git"


### PR DESCRIPTION
Vs code isn't picking up the types for me.

It shows this error:
```
Could not find a declaration file for module 'iv-viewer'. '<snip>/node_modules/iv-viewer/lib/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/iv-viewer` if it exists or add a new declaration (.d.ts) file containing `declare module 'iv-viewer';`ts(7016)
```

Putting in a types property into package.json fixes it.